### PR TITLE
Derive the upstream-tracking anchor instead of assuming it

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Then provide to your LLM Agent context about your company. The more context, the
 > 5. Populate the suppliers register with our key vendors.
 > 6. Populate the security feeds register with feeds relevant to our tech stack and sector.
 > 7. Run all checks and report which pass, which fail, and which are not applicable.
+> 8. Add this template as the `upstream` remote, tag its current `main` as `last-upstream-check`, and push the tag — so I can track template updates later.
+
+Step 8 is worth doing now: at instantiation time `upstream/main` is your starting point by definition, so the marker is correct for free. Recovering it later is possible but fiddlier — see [Staying up to date with the template](#staying-up-to-date-with-the-template).
 
 From there, iterate. The LLM can update policies and the SoA, run checks, maintain operational logs, refine risks, and keep cross-references in sync as your ISMS evolves.
 
@@ -155,16 +158,49 @@ git remote add upstream https://github.com/kriss-b/llm-iso27001.git
 
 **First time — mark your starting point:**
 
+If you tagged your starting point during initial setup, skip to the next step. Otherwise the marker has to be recovered, because **Use this template** squashes the template's history into a single Initial commit — your repo shares no commits with upstream, so there is no merge base to fall back on. Tagging `upstream/main` now would silently mark every template change since you instantiated as "already reviewed".
+
+Ask your LLM Agent:
+
+> Find the upstream commit this repository was created from by matching my root commit's tree against `upstream/main`, tag it `last-upstream-check`, and push the tag. Then show me the commits I have not reviewed.
+
+Template instantiation copies content verbatim, and git trees are content-addressed, so your root commit's tree hash is identical to that of the upstream commit it came from — an exact match, independent of commit timestamps:
+
 ```bash
-git tag last-upstream-check upstream/main
+root_tree=$(git rev-parse "$(git rev-list --max-parents=0 HEAD)^{tree}")
+git log --format='%H %T' upstream/main | awk -v t="$root_tree" '$2==t {print $1}'
 ```
+
+If that returns nothing, your first commit already contained local edits. Fall back to the commit date of your root commit (`git rev-list -n1 --before=<date> upstream/main`), then diff the candidates and pick the closest — and have the agent confirm it with you rather than accept it silently. If it returns more than one commit, upstream has commits with identical trees; use your root commit's date to choose between them.
+
+Then tag it and push it:
+
+```bash
+git tag last-upstream-check <the commit found above>
+git push origin last-upstream-check
+```
+
+Push the tag rather than keeping it local — it records how far you have reviewed upstream changes, which is auditable evidence of a review cadence, and it survives losing your working copy. Push it by name: `git push --tags` would also publish the template's own release tags onto your repo, since `git fetch upstream` brought them into your clone.
 
 **When you want to check for updates:**
 
 ```bash
 git fetch upstream
 git log --oneline last-upstream-check..upstream/main > upstream_changes.log
-git tag -f last-upstream-check upstream/main  # move the marker forward after review
+```
+
+After reviewing, move the marker forward. Publishing the move needs `--force`, because the tag is a moving bookmark being rewritten rather than immutable history:
+
+```bash
+git tag -f last-upstream-check upstream/main
+git push --force origin last-upstream-check
+```
+
+If you would rather keep the history of when reviews happened — so the tag list itself answers an auditor asking how often you review changes to your framework — add an immutable dated tag per round alongside the moving pointer:
+
+```bash
+git tag upstream-check-$(date +%F) upstream/main
+git push origin upstream-check-$(date +%F)
 ```
 
 Then open a session with your LLM Agent and say something like:


### PR DESCRIPTION
## Problem

The first-time step in "Staying up to date with the template" was:

```bash
git tag last-upstream-check upstream/main
```

This is only correct if you run it at the moment you instantiate the template. The README directs everyone to **Use this template**, which squashes the template's history into a single `Initial commit` — so a downstream ISMS shares **no commits** with upstream and there is no merge base to fall back on.

Set tracking up any later than instantiation, and the command silently marks every template change in between as "already reviewed". Nothing errors; the marker just quietly points at the wrong place. On the repo where this surfaced, the gap was six weeks and 60 commits.

## Fix

Derive the anchor from content rather than assuming it.

Template instantiation copies content verbatim, and git trees are content-addressed — so the downstream root commit's tree hash is identical to that of the upstream commit it came from:

```bash
root_tree=$(git rev-parse "$(git rev-list --max-parents=0 HEAD)^{tree}")
git log --format='%H %T' upstream/main | awk -v t="$root_tree" '$2==t {print $1}'
```

Exact, and independent of commit timestamps (a date-based lookup works but leans on metadata that rebases and timezones can skew). It is also self-verifying: a tree match *is* proof the content is identical.

Verified on a real downstream repo — returns exactly one commit, matching the anchor confirmed independently via an empty `git diff --stat`.

The README now documents both failure modes instead of letting an empty result look like success:

- **No match** — the first commit already contained local edits; fall back to the root commit's date, diff the candidates, and have the agent confirm with the user rather than accept silently.
- **Multiple matches** — upstream has commits with identical trees (a revert, or a merge that changed nothing); disambiguate by date.

Since the repo's idiom is natural-language instructions an agent executes rather than scripts, the recovery is presented primarily as an agent prompt, with the shell as the explanation. The agent can handle the ambiguous cases conversationally; a pasted one-liner cannot.

## Also in this PR

Three smaller fixes to the same section, from [#11](https://github.com/kriss-b/llm-iso27001/issues/11):

- **Prevention** — added tagging to the numbered init prompt (step 8), where `upstream/main` is the correct anchor by definition. Recovery becomes the repair path for existing downstreams rather than something every user needs.
- **Push the marker** — it records how far an org has reviewed upstream changes, which is auditable evidence of a review cadence and fits "Git is the audit trail". Documented as `git push origin last-upstream-check`, explicitly *not* `git push --tags`, which would publish the template's own `v0.1.0`/`v0.2.0` onto the downstream repo after `git fetch upstream` pulls them in.
- **`--force` when moving it** — legitimate here, since the tag is a moving bookmark rather than immutable history, but worth stating outright for users otherwise trained to distrust force-pushing. Optional dated tags (`upstream-check-YYYY-MM-DD`) offered for orgs that want the review cadence visible in the tag list.

Docs only — no ISMS documents, controls, or SoA entries touched.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
